### PR TITLE
Add pytest configuration for root pythonpath

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- ensure pytest can import project modules by setting PYTHONPATH to repository root

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --collect-only -q`

------
https://chatgpt.com/codex/tasks/task_b_689b36efd094833083645e8449322f10