### PR TITLE
Expose MCP server disabled state and UI toggle

### DIFF
--- a/docs/mcp_setup.md
+++ b/docs/mcp_setup.md
@@ -31,6 +31,10 @@ When you input and save your MCP server details in the UI, these settings are wr
 
 *   `tmp/settings.json`
 
+### Enabling or Disabling Servers
+
+Each server listed in the settings UI has a toggle next to its name. Use this control to enable or disable a server without editing the JSON manually. Toggling updates the underlying configuration and immediately refreshes the server status.
+
 ### The `mcp_servers` Setting in `tmp/settings.json`
 
 Within `tmp/settings.json`, the MCP servers are defined under the `"mcp_servers"` key.

--- a/python/helpers/mcp_handler.py
+++ b/python/helpers/mcp_handler.py
@@ -642,11 +642,16 @@ class MCPConfig(BaseModel):
                         "error": error,
                         "tool_count": tool_count,
                         "has_log": has_log,
+                        "disabled": False,
                     }
                 )
 
             # add failed servers
             for disconnected in self.disconnected_servers:
+                disabled = False
+                config = disconnected.get("config")
+                if isinstance(config, dict):
+                    disabled = bool(config.get("disabled", False))
                 result.append(
                     {
                         "name": disconnected["name"],
@@ -654,6 +659,7 @@ class MCPConfig(BaseModel):
                         "error": disconnected["error"],
                         "tool_count": 0,
                         "has_log": False,
+                        "disabled": disabled,
                     }
                 )
 

--- a/webui/components/settings/mcp/client/mcp-servers-store.js
+++ b/webui/components/settings/mcp/client/mcp-servers-store.js
@@ -92,6 +92,34 @@ const model = {
     }
   },
 
+  async toggleServer(name) {
+    try {
+      const current = JSON.parse(this.getEditorValue() || "[]");
+      let found = false;
+      for (const srv of current) {
+        if (srv.name === name) {
+          srv.disabled = !srv.disabled;
+          found = true;
+          break;
+        }
+      }
+      if (!found) return;
+      const formatted = JSON.stringify(current, null, 2);
+      this.editor.setValue(formatted);
+      this.editor.clearSelection();
+      const resp = await API.callJsonApi("mcp_servers_apply", {
+        mcp_servers: formatted,
+      });
+      if (resp.success) {
+        this.servers = resp.status;
+        this.servers.sort((a, b) => a.name.localeCompare(b.name));
+      }
+    } catch (error) {
+      console.error("Failed to toggle server:", error);
+      alert("Failed to toggle server: " + error.message);
+    }
+  },
+
   async stopStatusCheck() {
     this.statusCheck = false;
   },

--- a/webui/components/settings/mcp/client/mcp-servers.html
+++ b/webui/components/settings/mcp/client/mcp-servers.html
@@ -44,6 +44,10 @@
                                 <!-- Server name -->
                                 <span class="server-name" x-text="server.name"></span>
 
+                                <!-- Enable/disable toggle -->
+                                <input type="checkbox" :checked="server.disabled"
+                                    @change="$store.mcpServersStore.toggleServer(server.name)" />
+
                                 <!-- Tool count (clickable if > 0, only for connected servers without errors) -->
                                 <span class="tool-count" x-show="server.tool_count > 0"
                                     @click="$store.mcpServersStore.onToolCountClick && $store.mcpServersStore.onToolCountClick(server.name)"


### PR DESCRIPTION
## Summary
- Include `disabled` flag in MCP server status responses
- Add client-side toggle to update MCP server `disabled` state and apply changes
- Document enabling or disabling servers via settings toggle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ca53f92088330a5b387b50bd30fb1