### PR TITLE
feat: add per-provider model history

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -592,11 +592,32 @@
                                             </div>
 
                                             <div class="field-control">
-                                                <!-- Input field -->
-                                                <template x-if="field.type === 'text'">
+                                                <!-- Input field (non-model) -->
+                                                <template x-if="field.type === 'text' && !field.id.endsWith('_model_name')">
                                                     <input type="text" :class="field.classes" :value="field.value"
                                                         :readonly="field.readonly === true"
-                                                        @input="field.value = $event.target.value">
+                                                        @input="handleFieldInput(field, $event.target.value)">
+                                                </template>
+
+                                                <!-- Model name field with history dropdown -->
+                                                <template x-if="field.type === 'text' && field.id.endsWith('_model_name')">
+                                                    <div class="model-name-wrapper">
+                                                        <input type="text" :class="field.classes" :value="field.value"
+                                                            :readonly="field.readonly === true"
+                                                            @input="handleFieldInput(field, $event.target.value)"
+                                                            @blur="cacheModelName(field)">
+                                                        <div class="model-name-history" x-data="{selected: ''}" :data-type="field.id">
+                                                            <select x-model="selected"
+                                                                @change="handleFieldInput(field, selected)">
+                                                                <option value="">Saved models</option>
+                                                                <template x-for="name in getCachedModelNames(field)" :key="name">
+                                                                    <option :value="name" x-text="name"></option>
+                                                                </template>
+                                                            </select>
+                                                            <button type="button" class="remove-model-name" x-show="selected"
+                                                                @click="removeModelName(field, selected); selected='';">-</button>
+                                                        </div>
+                                                    </div>
                                                 </template>
 
                                                 <!-- Number field -->
@@ -654,7 +675,8 @@
                                                 <!-- Select field -->
                                                 <template x-if="field.type === 'select'">
                                                     <select :class="field.classes" x-model="field.value"
-                                                        :disabled="field.readonly === true">
+                                                        :disabled="field.readonly === true"
+                                                        @change="handleFieldChange(field)">
                                                         <template x-for="option in field.options" :key="option.value">
                                                             <option :value="option.value" x-text="option.label"
                                                                 :selected="option.value === field.value"></option>

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -5,6 +5,7 @@ const settingsModalProxy = {
     resolvePromise: null,
     activeTab: 'agent', // Default tab
     provider: 'cloudflared',
+    modelNameCache: JSON.parse(localStorage.getItem('modelNameCache') || '{}'),
 
     // Computed property for filtered sections
     get filteredSections() {
@@ -84,6 +85,120 @@ const settingsModalProxy = {
         }, 10);
     },
 
+    saveModelCache() {
+        localStorage.setItem('modelNameCache', JSON.stringify(this.modelNameCache));
+    },
+
+    findField(id) {
+        if (!this.settings || !this.settings.sections) return null;
+        for (const section of this.settings.sections) {
+            for (const field of section.fields) {
+                if (field.id === id) return field;
+            }
+        }
+        return null;
+    },
+
+    initModelCache() {
+        const types = ['chat', 'util', 'embed', 'browser'];
+        for (const type of types) {
+            const providerField = this.findField(`${type}_model_provider`);
+            const nameField = this.findField(`${type}_model_name`);
+            if (providerField && nameField) {
+                if (!this.modelNameCache[type]) this.modelNameCache[type] = {};
+                if (!Array.isArray(this.modelNameCache[type][providerField.value])) {
+                    this.modelNameCache[type][providerField.value] = [];
+                }
+                const arr = this.modelNameCache[type][providerField.value];
+                if (nameField.value && !arr.includes(nameField.value)) {
+                    arr.unshift(nameField.value);
+                }
+            }
+        }
+        this.saveModelCache();
+    },
+
+    handleFieldChange(field) {
+        if (field.id && field.id.endsWith('_model_provider')) {
+            const type = field.id.replace('_model_provider', '');
+            const nameField = this.findField(`${type}_model_name`);
+            if (nameField) {
+                const cached = this.modelNameCache[type] && this.modelNameCache[type][field.value];
+                if (Array.isArray(cached) && cached.length > 0) {
+                    nameField.value = cached[0];
+                } else {
+                    nameField.value = '';
+                }
+                // Reset any selected history dropdown
+                const historyEl = document.querySelector(`.model-name-history[data-type='${type}_model_name']`);
+                if (historyEl) {
+                    const data = Alpine.$data(historyEl);
+                    if (data && typeof data.selected !== 'undefined') {
+                        data.selected = '';
+                    }
+                }
+            }
+        }
+    },
+
+    handleFieldInput(field, value) {
+        field.value = value;
+    },
+
+    cacheModelName(field) {
+        if (field.id && field.id.endsWith('_model_name')) {
+            const type = field.id.replace('_model_name', '');
+            const providerField = this.findField(`${type}_model_provider`);
+            if (providerField) {
+                if (!this.modelNameCache[type]) this.modelNameCache[type] = {};
+                if (!Array.isArray(this.modelNameCache[type][providerField.value])) {
+                    this.modelNameCache[type][providerField.value] = [];
+                }
+                const arr = this.modelNameCache[type][providerField.value];
+                const name = field.value.trim();
+                if (name && !arr.includes(name)) {
+                    arr.unshift(name);
+                    this.saveModelCache();
+                }
+            }
+        }
+    },
+
+    getCachedModelNames(field) {
+        if (field.id && field.id.endsWith('_model_name')) {
+            const type = field.id.replace('_model_name', '');
+            const providerField = this.findField(`${type}_model_provider`);
+            if (providerField) {
+                const arr = this.modelNameCache[type] && this.modelNameCache[type][providerField.value];
+                return Array.isArray(arr) ? arr : [];
+            }
+        }
+        return [];
+    },
+
+    removeModelName(field, name) {
+        if (!name) return;
+        const type = field.id.replace('_model_name', '');
+        const providerField = this.findField(`${type}_model_provider`);
+        if (providerField && this.modelNameCache[type]) {
+            const arr = this.modelNameCache[type][providerField.value];
+            if (Array.isArray(arr)) {
+                this.modelNameCache[type][providerField.value] = arr.filter(n => n !== name);
+                this.saveModelCache();
+            }
+        }
+    },
+
+    updateModelCacheFromFields() {
+        const types = ['chat', 'util', 'embed', 'browser'];
+        for (const type of types) {
+            const nameField = this.findField(`${type}_model_name`);
+            if (nameField) {
+                this.cacheModelName(nameField);
+            }
+        }
+    },
+
     async openModal() {
         console.log('Settings modal opening');
         const modalEl = document.getElementById('settingsModal');
@@ -122,6 +237,7 @@ const settingsModalProxy = {
             // Update modal data
             modalAD.isOpen = true;
             modalAD.settings = settings;
+            modalAD.initModelCache();
 
             // Now set the active tab after the modal is open
             // This ensures Alpine reactivity works as expected
@@ -213,6 +329,9 @@ const settingsModalProxy = {
 
     async handleButton(buttonId) {
         if (buttonId === 'save') {
+
+            // Update model name cache with any new entries
+            this.updateModelCacheFromFields();
 
             const modalEl = document.getElementById('settingsModal');
             const modalAD = Alpine.$data(modalEl);


### PR DESCRIPTION
## Summary
- allow storing multiple model names per provider
- add dropdown with remove option for switching between saved models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ca11a26588330b260a0686871a74a