### PR TITLE
MCP per-server availability toggle (+ green active switch)

### DIFF
--- a/webui/components/settings/mcp/client/mcp-servers-store.js
+++ b/webui/components/settings/mcp/client/mcp-servers-store.js
@@ -11,42 +11,26 @@ const model = {
   serverLog: "",
 
   async initialize() {
-    // Initialize the JSON Viewer after the modal is rendered
     const container = document.getElementById("mcp-servers-config-json");
     if (container) {
       const editor = ace.edit("mcp-servers-config-json");
-
       const dark = localStorage.getItem("darkMode");
-      if (dark != "false") {
-        editor.setTheme("ace/theme/github_dark");
-      } else {
-        editor.setTheme("ace/theme/tomorrow");
-      }
-
+      editor.setTheme(dark != "false" ? "ace/theme/github_dark" : "ace/theme/tomorrow");
       editor.session.setMode("ace/mode/json");
       const json = this.getSettingsFieldConfigJson().value;
       editor.setValue(json);
       editor.clearSelection();
       this.editor = editor;
     }
-
     this.startStatusCheck();
   },
 
   formatJson() {
     try {
-      // get current content
-      const currentContent = this.editor.getValue();
-
-      // parse and format with 2 spaces indentation
-      const parsed = JSON.parse(currentContent);
+      const parsed = JSON.parse(this.editor.getValue());
       const formatted = JSON.stringify(parsed, null, 2);
-
-      // update editor content
       this.editor.setValue(formatted);
       this.editor.clearSelection();
-
-      // move cursor to start
       this.editor.navigateFileStart();
     } catch (error) {
       console.error("Failed to format JSON:", error);
@@ -54,9 +38,7 @@ const model = {
     }
   },
 
-  getEditorValue() {
-    return this.editor.getValue();
-  },
+  getEditorValue() { return this.editor.getValue(); },
 
   getSettingsFieldConfigJson() {
     return settingsModalProxy.settings.sections
@@ -73,13 +55,9 @@ const model = {
   async startStatusCheck() {
     this.statusCheck = true;
     let firstLoad = true;
-
     while (this.statusCheck) {
       await this._statusCheck();
-      if (firstLoad) {
-        this.loading = false;
-        firstLoad = false;
-      }
+      if (firstLoad) { this.loading = false; firstLoad = false; }
       await sleep(3000);
     }
   },
@@ -87,86 +65,67 @@ const model = {
   async _statusCheck() {
     const resp = await API.callJsonApi("mcp_servers_status", null);
     if (resp.success) {
-      this.servers = resp.status;
-      this.servers.sort((a, b) => a.name.localeCompare(b.name));
+      let cfg = {};
+      try { cfg = JSON.parse(this.getEditorValue() || "{}"); } catch (_) {}
+      const map = (cfg && cfg.mcpServers) ? cfg.mcpServers : {};
+      this.servers = resp.status
+        .map((s) => ({ ...s, disabled: !!(map[s.name] && map[s.name].disabled) }))
+        .sort((a, b) => a.name.localeCompare(b.name));
     }
   },
 
-  async toggleServer(name) {
+  async toggleServerEnabled(name, enabled) {
     try {
-      const current = JSON.parse(this.getEditorValue() || "[]");
-      let found = false;
-      for (const srv of current) {
-        if (srv.name === name) {
-          srv.disabled = !srv.disabled;
-          found = true;
-          break;
-        }
-      }
-      if (!found) return;
-      const formatted = JSON.stringify(current, null, 2);
+      let cfg = {};
+      try { cfg = JSON.parse(this.getEditorValue() || "{}"); } catch (_) { cfg = {}; }
+      cfg.mcpServers = cfg.mcpServers || {};
+      cfg.mcpServers[name] = cfg.mcpServers[name] || {};
+      cfg.mcpServers[name].disabled = !enabled; // inverse of enabled
+      const formatted = JSON.stringify(cfg, null, 2);
       this.editor.setValue(formatted);
       this.editor.clearSelection();
-      const resp = await API.callJsonApi("mcp_servers_apply", {
-        mcp_servers: formatted,
-      });
+      const resp = await API.callJsonApi("mcp_servers_apply", { mcp_servers: formatted });
       if (resp.success) {
-        this.servers = resp.status;
-        this.servers.sort((a, b) => a.name.localeCompare(b.name));
+        this.servers = resp.status
+          .map((s) => ({ ...s, disabled: !!(cfg.mcpServers[s.name] && cfg.mcpServers[s.name].disabled) }))
+          .sort((a, b) => a.name.localeCompare(b.name));
       }
     } catch (error) {
       console.error("Failed to toggle server:", error);
-      alert("Failed to toggle server: " + error.message);
+      alert("Failed to toggle server: " + (error?.message || error));
     }
   },
 
-  async stopStatusCheck() {
-    this.statusCheck = false;
-  },
+  async stopStatusCheck() { this.statusCheck = false; },
 
   async applyNow() {
     if (this.loading) return;
     this.loading = true;
     try {
       scrollModal("mcp-servers-status");
-      const resp = await API.callJsonApi("mcp_servers_apply", {
-        mcp_servers: this.getEditorValue(),
-      });
+      const resp = await API.callJsonApi("mcp_servers_apply", { mcp_servers: this.getEditorValue() });
       if (resp.success) {
         this.servers = resp.status;
         this.servers.sort((a, b) => a.name.localeCompare(b.name));
       }
       this.loading = false;
-      await sleep(100); // wait for ui and scroll
+      await sleep(100);
       scrollModal("mcp-servers-status");
-    } catch (error) {
-      console.error("Failed to apply MCP servers:", error);
-    }
+    } catch (error) { console.error("Failed to apply MCP servers:", error); }
     this.loading = false;
   },
 
   async getServerLog(serverName) {
     this.serverLog = "";
-    const resp = await API.callJsonApi("mcp_server_get_log", {
-      server_name: serverName,
-    });
-    if (resp.success) {
-      this.serverLog = resp.log;
-      openModal("settings/mcp/client/mcp-servers-log.html");
-    }
+    const resp = await API.callJsonApi("mcp_server_get_log", { server_name: serverName });
+    if (resp.success) { this.serverLog = resp.log; openModal("settings/mcp/client/mcp-servers-log.html"); }
   },
 
   async onToolCountClick(serverName) {
-    const resp = await API.callJsonApi("mcp_server_get_detail", {
-      server_name: serverName,
-    });
-    if (resp.success) {
-      this.serverDetail = resp.detail;
-      openModal("settings/mcp/client/mcp-server-tools.html");
-    }
+    const resp = await API.callJsonApi("mcp_server_get_detail", { server_name: serverName });
+    if (resp.success) { this.serverDetail = resp.detail; openModal("settings/mcp/client/mcp-server-tools.html"); }
   },
 };
 
 const store = createStore("mcpServersStore", model);
-
 export { store };

--- a/webui/components/settings/mcp/client/mcp-servers.html
+++ b/webui/components/settings/mcp/client/mcp-servers.html
@@ -25,43 +25,36 @@
 
                 <h3 id="mcp-servers-status">Servers status (refreshing automatically)</h3>
 
-
                 <div class="server-list" x-show="!$store.mcpServersStore.loading">
                     <template x-for="server in $store.mcpServersStore.servers" :key="server.name">
                         <div class="server-item">
                             <div class="server-main-row">
-                                <!-- Status indicator -->
                                 <div class="status-dot" x-data="{ connected: server.connected }">
                                     <svg viewBox="0 0 16 16" width="12" height="12">
-                                        <circle cx="8" cy="8" r="6" x-bind:fill="server.connected 
-                                                ? (server.error ? '#e40138' : (server.tool_count > 0 ? '#00c340' : '#e40138')) 
+                                        <circle cx="8" cy="8" r="6" x-bind:fill="server.connected
+                                                ? (server.error ? '#e40138' : (server.tool_count > 0 ? '#00c340' : '#e40138'))
                                                 : 'none'" x-bind:opacity="server.connected ? 1 : 0" />
                                         <circle cx="8" cy="8" r="6" fill="none" stroke="#e40138" stroke-width="2"
                                             x-bind:opacity="server.connected ? 0 : 1" />
                                     </svg>
                                 </div>
 
-                                <!-- Server name -->
                                 <span class="server-name" x-text="server.name"></span>
-
-                                <!-- Enable/disable toggle -->
-                                <label class="switch">
-                                    <input type="checkbox" :checked="server.disabled"
-                                        @change="$store.mcpServersStore.toggleServer(server.name)" />
-                                    <span class="slider server-toggle-slider"></span>
-                                </label>
-
-                                <!-- Tool count (clickable if > 0, only for connected servers without errors) -->
                                 <span class="tool-count" x-show="server.tool_count > 0"
                                     @click="$store.mcpServersStore.onToolCountClick && $store.mcpServersStore.onToolCountClick(server.name)"
                                     x-text="server.tool_count + ' tools'"></span>
-
-                                <!-- Log button (only shown if has_log is true) -->
                                 <span class="log-btn" x-show="server.has_log"
                                     @click="$store.mcpServersStore.getServerLog(server.name)">Log</span>
+
+                                <!-- Availability toggle (green when active) -->
+                                <label class="switch switch-green" style="margin-left:auto;">
+                                  <input type="checkbox" :checked="!server.disabled"
+                                         @change="$store.mcpServersStore.toggleServerEnabled(server.name, $event.target.checked)">
+                                  <span class="slider"></span>
+                                </label>
+                                <span class="switch-label" style="margin-left:0.4em;">this A0 instance available</span>
                             </div>
 
-                            <!-- Error message (if any) -->
                             <div class="server-error-row" x-show="server.error">
                                 <span class="server-error" x-text="server.error"></span>
                             </div>
@@ -80,115 +73,21 @@
     </div>
 
     <style>
+    .mcp-servers-loading { width: 100%; text-align: center; margin-top: 2rem; margin-bottom: 2rem; }
+    #mcp-servers-config-json { width: 100%; height: 40em; }
 
-    .mcp-servers-loading {
-        width: 100%;
-        text-align: center;
-        margin-top: 2rem;
-        margin-bottom: 2rem;
-    }
-        #mcp-servers-config-json {
-            width: 100%;
-            height: 40em;
-        }
+    .server-list { margin-top: 0.5em; margin-bottom: 1em; display:flex; flex-direction:column; gap:0.2em; }
+    .server-item { display:flex; flex-direction:column; padding:0.5em 0.7em; margin-bottom:0.4em; min-height:2.2em;
+                   border:1px solid rgba(192,192,192,0.161); border-radius:4px; }
+    .server-main-row { display:flex; align-items:center; gap:0.8em; width:100%; }
+    .status-dot { display:flex; align-items:center; justify-content:center; }
+    .server-name { font-weight:600; min-width:12em; }
+    .tool-count { color: var(--c-fg2); font-size:0.9em; user-select:none; }
+    .tool-count { cursor: default; }
 
-        .server-list {
-            margin-top: 0.5em;
-            margin-bottom: 1em;
-        }
-
-        .server-item {
-            display: flex;
-            flex-direction: column;
-            padding: 0.5em 0.7em;
-            margin-bottom: 0.4em;
-            min-height: 2.2em;
-            /* Ensure consistent height even without errors */
-            border: 1px solid rgba(192, 192, 192, 0.161);
-            /* Silver with 30% opacity */
-            border-radius: 4px;
-        }
-
-        .server-list {
-            margin-top: 0.5em;
-            margin-bottom: 1em;
-            display: flex;
-            flex-direction: column;
-            gap: 0.2em;
-        }
-
-        .server-main-row {
-            display: flex;
-            align-items: center;
-            gap: 0.8em;
-            width: 100%;
-        }
-
-        .status-dot {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .server-name {
-            font-weight: 600;
-            min-width: 12em;
-        }
-
-        .tool-count {
-            color: var(--c-fg2);
-            font-size: 0.9em;
-            user-select: none;
-        }
-
-        .tool-count {
-            cursor: default;
-        }
-
-        .tool-count:hover {
-            opacity: 0.8;
-            cursor: pointer;
-        }
-
-        .config-status {
-            color: #e40138;
-            font-size: 0.85em;
-            opacity: 0.8;
-        }
-
-        .log-btn {
-            margin-left: auto;
-            font-size: 0.9em;
-            cursor: pointer;
-            text-decoration: none;
-            opacity: 0.85;
-        }
-
-        .log-btn:hover {
-            opacity: 1;
-        }
-
-        .server-error-row {
-            margin-left: 1.8em;
-            margin-top: 0.1em;
-            font-size: 0.8em;
-            color: #F44336;
-            opacity: 0.85;
-            line-height: 1.2;
-        }
-
-        /* MCP server toggle accent */
-        .switch input:checked + .server-toggle-slider {
-            background-color: #00c340;
-        }
-
-        .no-servers {
-            padding: 0.5em;
-            color: var(--c-fg2);
-            font-style: italic;
-        }
+    /* Green active switch for MCP availability */
+    .switch-green input:checked + .slider { background-color: #00c340; box-shadow: 0 0 0 1px #00c340; }
+    .switch-green input:focus + .slider { box-shadow: 0 0 1px #00c340; }
     </style>
-
 </body>
-
 </html>


### PR DESCRIPTION
- Adds a per-server availability toggle in MCP settings list.
- Toggle binds to mcpServers[name].disabled (inverse of enabled).
- Updates the JSON editor and applies immediately; status refresh reflects change.
- Styles the switch green when active (checked) without affecting other switches.

Testing:
- Open Settings → MCP → Servers. Toggle any server; verify its "disabled" field is updated in the JSON editor and that status refresh shows it disconnected when disabled and connected when re-enabled.
- Confirm no errors in console and that Log/Tools still work.