### PR TITLE
Add hybrid compose and Kokoro worker for v0.9.8-custom-pre

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,7 +5,7 @@ services:
       context: ./docker/run
       dockerfile: Dockerfile
       args:
-        GIT_REF: v0.9.7-custom  # Pre-release tag with all custom features
+        GIT_REF: v0.9.8-custom-pre  # Pre-release tag with all custom features
         CACHE_DATE: ${CACHE_DATE:-none}
     volumes:
       - ./docker/run/fs/per:/per

--- a/docker-compose-hybrid.yml
+++ b/docker-compose-hybrid.yml
@@ -1,0 +1,41 @@
+name: a0-hybrid-custom
+
+services:
+  a0-hybrid:
+    container_name: A0-hybrid
+    build:
+      context: ./docker/run
+      dockerfile: Dockerfile
+      args:
+        GIT_REF: v0.9.8-custom-pre
+        CACHE_DATE: ${CACHE_DATE:-none}
+    ports:
+      - "8890:80"
+    environment:
+      - A0_TTS_REMOTE_WORKER=true
+      # Optional banner override; normally set from build info inside the image
+      # - A0_BUILD_VERSION=Version D hybridGPU v0.9.8-custom-pre ${A0_BUILD_TIMESTAMP:-unknown}
+    restart: unless-stopped
+    depends_on:
+      - kokoro-gpu-worker
+
+  kokoro-gpu-worker:
+    container_name: Kokoro-GPU-worker
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.kokoro
+    working_dir: /app
+    environment:
+      - KOKORO_DEVICE=cuda:auto
+      - KOKORO_HOST=0.0.0.0
+      - KOKORO_PORT=8891
+    ports:
+      - "8891:8891"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+

--- a/docker-compose-prerelease.yml
+++ b/docker-compose-prerelease.yml
@@ -5,7 +5,7 @@ services:
       context: ./docker/run
       dockerfile: Dockerfile
       args:
-        GIT_REF: v0.9.7-custom  # Change this to the desired pre-release tag
+        GIT_REF: v0.9.8-custom-pre  # Change this to the desired pre-release tag
         CACHE_DATE: ${CACHE_DATE:-none}
     volumes:
       - ./docker/run/fs/per:/per

--- a/docker/Dockerfile.kokoro
+++ b/docker/Dockerfile.kokoro
@@ -1,0 +1,51 @@
+# Optimized Dockerfile for Kokoro GPU Worker
+# ------------------------------------------
+# Uses a slim Python base and installs only the necessary ML/Audio dependencies
+# to significantly reduce image size compared to the full Agent Zero image.
+
+FROM python:3.10-slim
+
+# Install system dependencies
+# libsndfile1 is required for soundfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsndfile1 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install PyTorch with CUDA support
+# Using cu124 to match the main project's default
+RUN pip install --no-cache-dir \
+    torch==2.4.0+cu124 \
+    torchaudio==2.4.0+cu124 \
+    --index-url https://download.pytorch.org/whl/cu124
+
+# Install Kokoro and worker service dependencies
+RUN pip install --no-cache-dir \
+    flask[async]==3.0.3 \
+    kokoro>=0.9.2 \
+    soundfile==0.13.1 \
+    numpy==1.26.4 \
+    webcolors==24.6.0 \
+    python-dotenv==1.1.0
+
+# Copy the python package structure
+# We copy the whole python directory to ensure helpers/utils are available
+COPY python /app/python
+
+# Set PYTHONPATH so imports from 'python.helpers' work correctly
+ENV PYTHONPATH=/app
+
+# Environment variables for the worker
+ENV KOKORO_DEVICE=cuda:auto
+ENV KOKORO_HOST=0.0.0.0
+ENV KOKORO_PORT=8891
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8891/health || exit 1
+
+# Run the worker
+CMD ["python", "python/services/kokoro_gpu_worker.py"]
+

--- a/docker/compose.kokoro-remote.yml
+++ b/docker/compose.kokoro-remote.yml
@@ -1,0 +1,34 @@
+# Remote Kokoro GPU worker stack
+# --------------------------------
+# Layer this file with either docker-compose-dev.yml or docker-compose-test.yml
+# to launch a lightweight GPU worker container alongside the main Agent Zero
+# container:
+#
+#   docker compose -f docker-compose-dev.yml -f docker/compose.kokoro-remote.yml up -d
+#
+# The primary container will continue running on CPU while the worker consumes
+# the GPU for Kokoro requests.
+
+services:
+  kokoro-gpu-worker:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.kokoro
+    command: ["python", "python/services/kokoro_gpu_worker.py"]
+    working_dir: /app
+    environment:
+      - KOKORO_DEVICE=cuda:auto
+      - KOKORO_HOST=0.0.0.0
+      - KOKORO_PORT=8891
+      # Uncomment to enforce token auth:
+      # - KOKORO_WORKER_TOKEN=super-secret-token
+    ports:
+      - "8891:8891"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+


### PR DESCRIPTION
## Summary
- add hybrid compose stack (main + Kokoro GPU worker) targeting v0.9.8-custom-pre
- add Kokoro worker Dockerfile and compose overlay
- bump compose dev/prerelease GIT_REF to v0.9.8-custom-pre

## Testing
- not run here; existing hybrid image tag will be built/published in downstream step