### PR TITLE
Fix hybrid build: pin whisper and use uv venv py3.11

### DIFF
--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -10,6 +10,11 @@ ENV GIT_REF=$GIT_REF
 # Backward compatibility: also set BRANCH for scripts that still use it
 ENV BRANCH=$GIT_REF
 
+# Recreate venv on Python 3.11 via uv (whisper wheels not available for 3.13)
+RUN rm -rf /opt/venv && uv venv --python 3.11 /opt/venv \
+    && /opt/venv/bin/python -m ensurepip \
+    && /opt/venv/bin/pip3 install --upgrade pip
+
 # Copy filesystem files to root
 COPY ./fs/ /
 

--- a/docker/run/fs/ins/install_A0.sh
+++ b/docker/run/fs/ins/install_A0.sh
@@ -56,18 +56,21 @@ echo "$BUILD_VERSION" > /tmp/A0_BUILD_VERSION.txt
 
 . "/ins/setup_venv.sh" "$@"
 
+# Ensure tooling compatibility (whisper build on Python 3.13)
+pip install "setuptools<81" wheel
+
 # Validate and fix critical dependencies (e.g., fastmcp==2.3.0)
 echo "Validating critical dependencies..."
 bash /ins/validate_dependencies.sh /git/agent-zero
 
-# moved to base image
-# # Ensure the virtual environment and pip setup
-# pip install --upgrade pip ipython requests
-# # Install some packages in specific variants
-# pip install torch --index-url https://download.pytorch.org/whl/cpu
+# Patch whisper requirement for py3.11 compatibility
+sed -i 's/openai-whisper==20240930/openai-whisper==20231117/' /git/agent-zero/requirements.txt
 
-# Install remaining A0 python packages
-uv pip install -r /git/agent-zero/requirements.txt
+# Install dependencies with a whisper constraint for py3.13
+echo "openai-whisper==20231117" > /tmp/constraints.txt
+pip install -r /git/agent-zero/requirements.txt -c /tmp/constraints.txt
+# Ensure key deps present
+pip install "litellm==1.75.0" "aiohttp==3.10.5"
 
 # Safety check: explicitly ensure fastmcp==2.3.0 is installed (overrides if wrong version was installed)
 echo "Ensuring fastmcp==2.3.0 is correctly installed..."

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ simpleeval==1.0.3
 langchain-core==0.3.49
 langchain-community==0.3.19
 langchain-unstructured[all-docs]==0.1.6
-openai-whisper==20240930
+openai-whisper==20231117
 lxml_html_clean==0.3.1
 markdown==3.7
 mcp==1.13.1


### PR DESCRIPTION
## Summary
- recreate venv with uv on Python 3.11 (whisper wheels are unavailable for 3.13)
- pin openai-whisper to 20231117 and enforce via requirements patch during install
- ensure litellm 1.75.0 and aiohttp 3.10.5 are installed

## Testing
- docker build succeeds for v0.9.8-custom-pre-hybrid with these changes