### PR TITLE
Add missing agent.extras.project.file_structure.md prompt

### DIFF
--- a/prompts/agent.extras.project.file_structure.md
+++ b/prompts/agent.extras.project.file_structure.md
@@ -1,0 +1,9 @@
+# File structure of project {{project_name}}
+- this is filtered overview not full scan
+- list yourself if needed
+- maximum depth: {{max_depth}}
+- ignored:
+{{gitignore}}
+
+## file tree
+{{file_structure}}


### PR DESCRIPTION
## Summary
Adds the missing `agent.extras.project.file_structure.md` prompt file that was causing `FileNotFoundError` in the agent chat when using project features.

## Changes
- Added `prompts/agent.extras.project.file_structure.md` template file

## Related Issue
This fixes the error: `FileNotFoundError: File 'agent.extras.project.file_structure.md' not found` that occurs when interacting with projects in the FullGPU build.

## Testing
After this merge, the development branch will have all 4 required project prompt files:
- ✅ `agent.system.projects.main.md`
- ✅ `agent.system.projects.active.md`
- ✅ `agent.system.projects.inactive.md`
- ✅ `agent.extras.project.file_structure.md` (added by this PR)