### PR TITLE
fix: optimize install_A02.sh to prevent image bloat

### DIFF
--- a/docker/run/fs/ins/install_A0.sh
+++ b/docker/run/fs/ins/install_A0.sh
@@ -23,8 +23,8 @@ if [ "$GIT_REF" = "local" ]; then
     # List all files recursively in the target directory
     # echo "All files in /git/agent-zero (recursive):"
     # find "/git/agent-zero" -type f | sort
-elif [ "$GIT_REF" = "development" ] || [ "$IS_TAG" = true ] || [[ "$GIT_REF" == feature/hybrid-* ]]; then
-    # For development branch, tags, or hybrid feature branches, use Omni-NexusAI fork (validated custom features)
+elif [ "$GIT_REF" = "development" ] || [ "$IS_TAG" = true ] || [[ "$GIT_REF" == feature/* ]] || [[ "$GIT_REF" == fix/* ]]; then
+    # For development branch, tags, feature branches, or fix branches, use Omni-NexusAI fork
     echo "Cloning $GIT_REF from Omni-NexusAI repository..."
     git clone -b "$GIT_REF" "https://github.com/Omni-NexusAI/agent-zero" "/git/agent-zero" || {
         echo "CRITICAL ERROR: Failed to clone $GIT_REF from Omni-NexusAI"

--- a/docker/run/fs/ins/install_A02.sh
+++ b/docker/run/fs/ins/install_A02.sh
@@ -1,26 +1,53 @@
 #!/bin/bash
 set -e
 
-# cachebuster script, this helps speed up docker builds
+# OPTIMIZED cachebuster script - refreshes code ONLY, does NOT reinstall dependencies
+# This prevents creating duplicate multi-GB layers in Docker
+# The goal is to bust the cache to pull latest code without re-running pip install
 
-# remove repo (if not local branch)
-if [ "$1" != "local" ]; then
-    rm -rf /git/agent-zero
+GIT_REF="$1"
+
+# Detect if GIT_REF is a tag
+IS_TAG=false
+if [[ "$GIT_REF" =~ ^v[0-9] ]] || [[ "$GIT_REF" =~ -custom$ ]] || [[ "$GIT_REF" =~ ^v[0-9]+\.[0-9] ]]; then
+    IS_TAG=true
 fi
 
-# run the original install script again (this will recompute version)
-bash /ins/install_A0.sh "$@"
+if [ "$GIT_REF" != "local" ] && [ -d /git/agent-zero/.git ]; then
+    echo "Refreshing A0 code (preserving installed dependencies)..."
+    cd /git/agent-zero
+    
+    # Fetch latest changes
+    git fetch origin --tags --force
+    
+    # Reset to the target ref
+    if [ "$IS_TAG" = true ]; then
+        echo "Checking out tag: $GIT_REF"
+        git checkout "$GIT_REF" --force
+    else
+        echo "Resetting to branch: $GIT_REF"
+        git checkout "$GIT_REF" --force 2>/dev/null || git checkout -b "$GIT_REF" "origin/$GIT_REF" --force
+        git reset --hard "origin/$GIT_REF"
+    fi
+    
+    echo "Code refreshed successfully"
+elif [ "$GIT_REF" = "local" ]; then
+    echo "Using local development files (no refresh needed)"
+elif [ ! -d /git/agent-zero ]; then
+    echo "No existing A0 installation found, running full install..."
+    bash /ins/install_A0.sh "$@"
+fi
 
-# Recompute and save build version after reinstall
+# Recompute and save build version
 # BUILD_VARIANT env var is inherited from Dockerfile (hybridGPU, fullGPU, or empty)
 if [ -d /git/agent-zero/.git ]; then
-    echo "Recomputing build version after reinstall (variant: ${BUILD_VARIANT:-cpu-only})..."
+    echo "Recomputing build version (variant: ${BUILD_VARIANT:-cpu-only})..."
     BUILD_VERSION=$(BUILD_VARIANT="$BUILD_VARIANT" bash /ins/compute_build_version.sh /git/agent-zero | tr -d '\n\r')
     echo "$BUILD_VERSION" > /tmp/A0_BUILD_VERSION.txt
     echo "Build version recomputed: $BUILD_VERSION"
 fi
 
-# remove python packages cache
+# Activate venv and clean caches
 . "/ins/setup_venv.sh" "$@"
 pip cache purge
 uv cache prune


### PR DESCRIPTION
## Summary
Optimizes `install_A02.sh` to prevent Docker image bloat.

## Problem
The current `install_A02.sh` does:
1. `rm -rf /git/agent-zero`
2. `bash /ins/install_A0.sh "$@"`

This **reinstalls all Python packages** (~7GB+), creating duplicate layers and causing the image to balloon from ~20GB to ~31.5GB.

## Solution
Changed to only refresh git code **without** reinstalling packages:
- Uses `git fetch`, `git checkout`, `git reset --hard` instead
- Preserves installed Python dependencies
- Only runs full `install_A0.sh` if repo doesn't exist

## Testing Required
Build from this branch and verify:
1. Image size is ~18-20GB (not ~31GB)
2. Agent chat works (no missing `.md` file errors)
3. Version banner displays correctly

## Build Command
```bash
docker build -t a0-fullgpu-test:latest \
  --build-arg GIT_REF=fix/install-a02-bloat \
  --build-arg BUILD_VARIANT=fullGPU \
  --build-arg PYTORCH_VARIANT=cuda \
  --build-arg CACHE_DATE=$(date +%Y-%m-%d) \
  --no-cache \
  docker/run
```