### PR TITLE
feat: remember context lengths and default local provider URLs

### DIFF
--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -128,6 +128,7 @@ class Settings(TypedDict):
     litellm_global_kwargs: dict[str, Any]
 
     models_history: dict[str, dict[str, list[str]]]
+    models_context_history: dict[str, dict[str, dict[str, int]]]
 
 class PartialSettings(Settings, total=False):
     pass
@@ -173,6 +174,7 @@ class SettingsSection(TypedDict, total=False):
 class SettingsOutput(TypedDict):
     sections: list[SettingsSection]
     models_history: dict[str, dict[str, list[str]]]
+    models_context_history: dict[str, dict[str, dict[str, int]]]
 
 
 PASSWORD_PLACEHOLDER = "****PSWD****"
@@ -1437,6 +1439,7 @@ def convert_out(settings: Settings) -> SettingsOutput:
         ]
     }
     result["models_history"] = settings.get("models_history", {})
+    result["models_context_history"] = settings.get("models_context_history", {})
     return result
 
 
@@ -1473,6 +1476,9 @@ def convert_in(settings: dict) -> Settings:
 
     if "models_history" in settings:
         current["models_history"] = settings["models_history"]
+
+    if "models_context_history" in settings:
+        current["models_context_history"] = settings["models_context_history"]
 
     return current
 
@@ -1682,6 +1688,7 @@ def get_default_settings() -> Settings:
         secrets="",
         litellm_global_kwargs={},
         models_history={},
+        models_context_history={},
     )
 
 

--- a/test_clearing_url.py
+++ b/test_clearing_url.py
@@ -1,0 +1,3 @@
+from python.helpers.settings import Settings
+s = Settings()
+# Check if the code parses it right - well the logic is in JS, so JS tests are better

--- a/update_settings_js.py
+++ b/update_settings_js.py
@@ -1,0 +1,35 @@
+import re
+
+with open('webui/js/settings.js', 'r') as f:
+    content = f.read()
+
+replacement = """        // If provider changed for chat model, apply default URLs for local providers
+        if (field.id === 'chat_model_provider' && this.settings && this.settings.sections) {
+            const section = this.settings.sections.find(s => s.fields && s.fields.includes(field));
+            if (section) {
+                const apiBaseField = section.fields.find(f => f.id === 'chat_model_api_base');
+                if (apiBaseField) {
+                    if (value === 'lm_studio') {
+                        if (!apiBaseField.value || apiBaseField.value.trim() === '') {
+                            apiBaseField.value = 'http://localhost:1234/v1';
+                        }
+                    } else if (value === 'ollama') {
+                        if (!apiBaseField.value || apiBaseField.value.trim() === '') {
+                            apiBaseField.value = 'http://localhost:11434';
+                        }
+                    } else {
+                        // Clear out the URL if the user switches away from a local provider
+                        // and the URL is still set to one of the defaults
+                        if (apiBaseField.value === 'http://localhost:1234/v1' || apiBaseField.value === 'http://localhost:11434') {
+                            apiBaseField.value = '';
+                        }
+                    }
+                }
+            }
+        }"""
+
+pattern = re.compile(r"        // If provider changed for chat model, apply default URLs for local providers.*?        }", re.DOTALL)
+new_content = pattern.sub(replacement, content)
+
+with open('webui/js/settings.js', 'w') as f:
+    f.write(new_content)

--- a/webui/index.html
+++ b/webui/index.html
@@ -400,7 +400,8 @@
 
                                                 <!-- Default select rendering -->
                                                 <template x-if="field.type === 'select' && !(field.id === 'tts_kokoro_voice' || field.id === 'tts_kokoro_voice_secondary')">
-                                                    <select :class="field.classes" x-model="field.value"
+                                                    <select :class="field.classes" :value="field.value"
+                                                        @change="handleSelectChange(field, $event.target.value)"
                                                         :disabled="field.id === 'tts_device' ? (section.fields.find(f => f.id === 'tts_kokoro')?.value === false) : (field.readonly === true)">
                                                         <template x-for="option in field.options" :key="option.value">
                                                             <option :value="option.value" x-text="option.label"

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -127,7 +127,8 @@ const settingsModalProxy = {
                     }
                 ],
                 "sections": set.settings.sections,
-                "models_history": set.settings.models_history || {}
+                "models_history": set.settings.models_history || {},
+                "models_context_history": set.settings.models_context_history || {}
             }
 
             // Initialize model picker dropdown flags before wiring to modal
@@ -439,6 +440,18 @@ const settingsModalProxy = {
 
         // Limit
         this.settings.models_history[field.id][provider] = filtered.slice(0, 20);
+
+        // Also cache context length if applicable
+        if (field.id === 'chat_model_name') {
+            const ctxLengthField = section.fields.find(f => f.id === 'chat_model_ctx_length');
+            if (ctxLengthField) {
+                if (!this.settings.models_context_history) this.settings.models_context_history = {};
+                if (!this.settings.models_context_history[field.id]) this.settings.models_context_history[field.id] = {};
+                if (!this.settings.models_context_history[field.id][provider]) this.settings.models_context_history[field.id][provider] = {};
+
+                this.settings.models_context_history[field.id][provider][val] = parseInt(ctxLengthField.value, 10) || 128000;
+            }
+        }
     },
 
     saveModelName(field, section) {
@@ -515,10 +528,50 @@ const settingsModalProxy = {
     selectModelName(field, modelName) {
         field.value = modelName;
         field.showDropdown = false;
+
+        // Apply cached context length if applicable
+        if (field.id === 'chat_model_name' && this.settings && this.settings.sections) {
+            const section = this.settings.sections.find(s => s.fields && s.fields.includes(field));
+            if (section) {
+                const providerField = this.getProviderField(field, section);
+                const provider = providerField ? providerField.value : 'unknown';
+
+                if (this.settings.models_context_history &&
+                    this.settings.models_context_history[field.id] &&
+                    this.settings.models_context_history[field.id][provider] &&
+                    this.settings.models_context_history[field.id][provider][modelName]) {
+
+                    const ctxLength = this.settings.models_context_history[field.id][provider][modelName];
+                    const ctxLengthField = section.fields.find(f => f.id === 'chat_model_ctx_length');
+                    if (ctxLengthField) {
+                        ctxLengthField.value = ctxLength;
+                    }
+                }
+            }
+        }
     },
 
     handleFieldInput(field, value) {
         field.value = value;
+    },
+
+    handleSelectChange(field, value) {
+        field.value = value;
+
+        // If provider changed for chat model, apply default URLs for local providers
+        if (field.id === 'chat_model_provider' && this.settings && this.settings.sections) {
+            const section = this.settings.sections.find(s => s.fields && s.fields.includes(field));
+            if (section) {
+                const apiBaseField = section.fields.find(f => f.id === 'chat_model_api_base');
+                if (apiBaseField) {
+                    if (value === 'lm_studio' && (!apiBaseField.value || apiBaseField.value.trim() === '')) {
+                        apiBaseField.value = 'http://localhost:1234/v1';
+                    } else if (value === 'ollama' && (!apiBaseField.value || apiBaseField.value.trim() === '')) {
+                        apiBaseField.value = 'http://localhost:11434';
+                    }
+                }
+            }
+        }
     },
 
     cacheAllModelNames(sections) {

--- a/webui/js/settings.js
+++ b/webui/js/settings.js
@@ -564,9 +564,24 @@ const settingsModalProxy = {
             if (section) {
                 const apiBaseField = section.fields.find(f => f.id === 'chat_model_api_base');
                 if (apiBaseField) {
-                    if (value === 'lm_studio' && (!apiBaseField.value || apiBaseField.value.trim() === '')) {
-                        apiBaseField.value = 'http://localhost:1234/v1';
-                    } else if (value === 'ollama' && (!apiBaseField.value || apiBaseField.value.trim() === '')) {
+                    if (value === 'lm_studio') {
+                        if (!apiBaseField.value || apiBaseField.value.trim() === '') {
+                            apiBaseField.value = 'http://localhost:1234/v1';
+                        }
+                    } else if (value === 'ollama') {
+                        if (!apiBaseField.value || apiBaseField.value.trim() === '') {
+                            apiBaseField.value = 'http://localhost:11434';
+                        }
+                    } else {
+                        // Clear out the URL if the user switches away from a local provider
+                        // and the URL is still set to one of the defaults
+                        if (apiBaseField.value === 'http://localhost:1234/v1' || apiBaseField.value === 'http://localhost:11434') {
+                            apiBaseField.value = '';
+                        }
+                    }
+                }
+            }
+        } else if (value === 'ollama' && (!apiBaseField.value || apiBaseField.value.trim() === '')) {
                         apiBaseField.value = 'http://localhost:11434';
                     }
                 }


### PR DESCRIPTION
This commit implements the requirements to store the selected context length per chat model and provider, and to auto-fill the API base URLs when `lm_studio` or `ollama` are selected from the dropdowns if empty.

- Added `models_context_history` to `python/helpers/settings.py` TypedDict.
- Updated `webui/js/settings.js` to hook into `selectModelName` and `cacheModelName` for remembering context length limits.
- Added `handleSelectChange` in `webui/js/settings.js` (hooked into `webui/index.html`) to auto-populate the local URL API paths for `lm_studio` and `ollama` when chosen as the provider.

---
*PR created automatically by Jules for task [6349829137884368911](https://jules.google.com/task/6349829137884368911) started by @Omni-NexusAI*